### PR TITLE
Добавил sw.js и manifest.json для PWA

### DIFF
--- a/static/manifest/manifest.json
+++ b/static/manifest/manifest.json
@@ -1,0 +1,17 @@
+{
+	"name" : "Карта бизнеса, терпящего бедствие",
+	"short_name" : "Бизнес в беде",
+	"theme_color" : "transparent",
+	"description" : "Эта карта — сигнал тревоги. Мы призываем предпринимателей, которые терпят крах из-за карантина, размещать на ней метки с обозначением своего бизнеса.",
+	"orientation" : "any",
+	"background_color" : "transparent",
+	"icons" : [
+		{
+			"src": "https://biz-alert.ru/favicon.png",
+			"sizes": "32x32"
+		}
+    ],
+	"scope" : "/",
+	"start_url" : "/",
+    "display": "standalone"
+}

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,1 +1,47 @@
-// THIS FILE SHOULD NOT BE VERSION CONTROLLED
+// This is the "Offline page" service worker
+
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/5.0.0/workbox-sw.js');
+
+const CACHE = "pwabuilder-page";
+
+// TODO: сделать fallback-страницу
+const offlineFallbackPage = "ToDo-replace-this-name.html";
+
+self.addEventListener("message", (event) => {
+  if (event.data && event.data.type === "SKIP_WAITING") {
+    self.skipWaiting();
+  }
+});
+
+self.addEventListener('install', async (event) => {
+  event.waitUntil(
+    caches.open(CACHE)
+      .then((cache) => cache.add(offlineFallbackPage))
+  );
+});
+
+if (workbox.navigationPreload.isSupported()) {
+  workbox.navigationPreload.enable();
+}
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.mode === 'navigate') {
+    event.respondWith((async () => {
+      try {
+        const preloadResp = await event.preloadResponse;
+
+        if (preloadResp) {
+          return preloadResp;
+        }
+
+        const networkResp = await fetch(event.request);
+        return networkResp;
+      } catch (error) {
+
+        const cache = await caches.open(CACHE);
+        const cachedResp = await cache.match(offlineFallbackPage);
+        return cachedResp;
+      }
+    })());
+  }
+});


### PR DESCRIPTION
- [ ] ### Подключить manifest
Предполагаю, что есть один единственный html-файл index.html
Ему в `<head>` надо прописать `<link rel='manifest' href='static/manifest/manifest.json'>`

- [ ] ### Подключить sw.js
1. Нужно отдавать файл sw.js по урлу /sw.js, то есть из корня (/static/sw.js и другое НЕЛЬЗЯ!!!)
2. Нужно подключить sw.js в index.html следующим скриптом:
`<script>
   if ('serviceWorker' in navigator) {
       window.addEventListener('load', function() {
           navigator.serviceWorker.register('/sw.js').then(function(registration) {
               // Registration was successful
               console.log('ServiceWorker успешно зарегистрирован со сферой действия: ', registration.scope);
               }, function(err) {
               // registration failed :(
               console.log('ServiceWorker не удалось зарегистрировать: ', err);
           }).catch(function(err) {
               console.log(err)
           });
       });
   } else {
       console.log('ServiceWorker не поддерживается');
   }
</script>`

**Примечание**: возможно, nuxt делает всё это автоматом

- [ ] Когда появятся иконки, пути до них нужно будет прописать в массив icons внутри manifest.json